### PR TITLE
HW3. creating COW buffer

### DIFF
--- a/homework/strings/homework_test.go
+++ b/homework/strings/homework_test.go
@@ -1,74 +1,149 @@
 package main
 
 import (
-	"reflect"
 	"testing"
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
 
-type COWBuffer struct {
+type SharedBuffer struct {
 	data []byte
-	refs *int
-	// need to implement
+	refs int
+}
+
+type COWBuffer struct {
+	sharedData *SharedBuffer
 }
 
 func NewCOWBuffer(data []byte) COWBuffer {
-	return COWBuffer{} // need to implement
+	return COWBuffer{
+		&SharedBuffer{
+			data: data,
+			refs: 1,
+		},
+	}
 }
 
 func (b *COWBuffer) Clone() COWBuffer {
-	return COWBuffer{} // need to implement
+	if b.sharedData == nil {
+		panic("clone of closed buffer")
+	}
+	b.sharedData.refs++
+	return COWBuffer{
+		b.sharedData,
+	}
 }
 
 func (b *COWBuffer) Close() {
-	// need to implement
+	if b.sharedData == nil {
+		return
+	}
+	b.sharedData.refs--
+	b.sharedData = nil
 }
 
 func (b *COWBuffer) Update(index int, value byte) bool {
-	return false // need to implement
+	if b.sharedData == nil {
+		return false
+	}
+	if index < 0 || index >= len(b.sharedData.data) {
+		return false
+	}
+	if b.sharedData.refs > 1 {
+		copyData := make([]byte, len(b.sharedData.data))
+		copy(copyData, b.sharedData.data)
+		copyData[index] = value
+		b.sharedData.refs--
+		b.sharedData = &SharedBuffer{
+			data: copyData,
+			refs: 1,
+		}
+		return true
+	}
+	b.sharedData.data[index] = value
+	return true
 }
 
 func (b *COWBuffer) String() string {
-	return "" // need to implement
+	if b.sharedData == nil {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b.sharedData.data), len(b.sharedData.data))
 }
 
 func TestCOWBuffer(t *testing.T) {
-	data := []byte{'a', 'b', 'c', 'd'}
-	buffer := NewCOWBuffer(data)
-	defer buffer.Close()
+	original := []byte{'a', 'b', 'c', 'd'}
 
+	buffer := NewCOWBuffer(original)
 	copy1 := buffer.Clone()
 	copy2 := buffer.Clone()
 
-	assert.Equal(t, unsafe.SliceData(data), unsafe.SliceData(buffer.data))
-	assert.Equal(t, unsafe.SliceData(buffer.data), unsafe.SliceData(copy1.data))
-	assert.Equal(t, unsafe.SliceData(copy1.data), unsafe.SliceData(copy2.data))
+	defer buffer.Close()
+	defer copy1.Close()
+	defer copy2.Close()
 
-	assert.True(t, (*byte)(unsafe.SliceData(data)) == unsafe.StringData(buffer.String()))
-	assert.True(t, (*byte)(unsafe.StringData(buffer.String())) == unsafe.StringData(copy1.String()))
-	assert.True(t, (*byte)(unsafe.StringData(copy1.String())) == unsafe.StringData(copy2.String()))
+	assert.Same(t, buffer.sharedData, copy1.sharedData)
+	assert.Same(t, copy1.sharedData, copy2.sharedData)
+
+	assert.Equal(t, 3, buffer.sharedData.refs)
+
+	assert.Equal(t,
+		unsafe.SliceData(buffer.sharedData.data),
+		unsafe.SliceData(copy1.sharedData.data),
+	)
+	assert.Equal(t,
+		unsafe.SliceData(copy1.sharedData.data),
+		unsafe.SliceData(copy2.sharedData.data),
+	)
+
+	assert.Same(t,
+		unsafe.StringData(buffer.String()),
+		unsafe.SliceData(buffer.sharedData.data),
+	)
+	assert.Same(t,
+		unsafe.StringData(copy1.String()),
+		unsafe.SliceData(copy1.sharedData.data),
+	)
+	assert.Same(t,
+		unsafe.StringData(copy2.String()),
+		unsafe.SliceData(copy2.sharedData.data),
+	)
 
 	assert.True(t, buffer.Update(0, 'g'))
 	assert.False(t, buffer.Update(-1, 'g'))
 	assert.False(t, buffer.Update(4, 'g'))
 
-	assert.True(t, reflect.DeepEqual([]byte{'g', 'b', 'c', 'd'}, buffer.data))
-	assert.True(t, reflect.DeepEqual([]byte{'a', 'b', 'c', 'd'}, copy1.data))
-	assert.True(t, reflect.DeepEqual([]byte{'a', 'b', 'c', 'd'}, copy2.data))
+	assert.NotSame(t, buffer.sharedData, copy1.sharedData)
+	assert.Same(t, copy1.sharedData, copy2.sharedData)
 
-	assert.NotEqual(t, unsafe.SliceData(buffer.data), unsafe.SliceData(copy1.data))
-	assert.Equal(t, unsafe.SliceData(copy1.data), unsafe.SliceData(copy2.data))
+	assert.Equal(t, 1, buffer.sharedData.refs)
+	assert.Equal(t, 2, copy1.sharedData.refs)
+
+	assert.Equal(t, []byte{'g', 'b', 'c', 'd'}, buffer.sharedData.data)
+	assert.Equal(t, []byte{'a', 'b', 'c', 'd'}, copy1.sharedData.data)
+	assert.Equal(t, []byte{'a', 'b', 'c', 'd'}, copy2.sharedData.data)
+
+	assert.NotEqual(t,
+		unsafe.SliceData(buffer.sharedData.data),
+		unsafe.SliceData(copy1.sharedData.data),
+	)
+
+	assert.Equal(t,
+		unsafe.SliceData(copy1.sharedData.data),
+		unsafe.SliceData(copy2.sharedData.data),
+	)
 
 	copy1.Close()
 
-	previous := copy2.data
-	copy2.Update(0, 'f')
-	current := copy2.data
+	assert.Equal(t, 1, copy2.sharedData.refs)
 
-	// 1 reference - don't need to copy buffer during update
-	assert.Equal(t, unsafe.SliceData(previous), unsafe.SliceData(current))
+	before := unsafe.SliceData(copy2.sharedData.data)
 
-	copy2.Close()
+	assert.True(t, copy2.Update(0, 'f'))
+
+	after := unsafe.SliceData(copy2.sharedData.data)
+
+	assert.Equal(t, before, after)
+	assert.Equal(t, []byte{'f', 'b', 'c', 'd'}, copy2.sharedData.data)
 }


### PR DESCRIPTION
Изменил немного структуру самого буффера, чтоб всё разделяемое состояние жило в одном объекте + переписал тесты, т.к. они стали проще из за смены контракта структуры.